### PR TITLE
Fix Codex CLI compatibility with current config behavior

### DIFF
--- a/src/ai.rs
+++ b/src/ai.rs
@@ -636,13 +636,11 @@ mod cli_backend {
             cmd.arg("--skip-git-repo-check");
         }
         cmd.arg("--json");
-        let reasoning = req.reasoning_effort.unwrap_or("minimal");
+        let reasoning = req.reasoning_effort.unwrap_or("low");
         cmd.arg("-c");
         cmd.arg(format!("model_reasoning_effort={}", reasoning));
         cmd.arg("-c");
         cmd.arg("sandbox_mode=read-only");
-        cmd.arg("-c");
-        cmd.arg("tools.web_search=false");
         cmd.arg("-");
 
         let prompt = format!(


### PR DESCRIPTION
This updates the Codex CLI integration to work with current Codex behavior.

Observed failures:
1. qqqa passed:
   -c "tools.web_search=false"

   Codex rejected this with:
   invalid type: boolean `false`, expected struct WebSearchToolConfig
   in `tools.web_search`

2. After removing that override, qqqa still passed:
   -c "model_reasoning_effort=minimal"

   Codex then rejected the request because web_search could not be used with reasoning effort `minimal`.

Changes in this PR:
- remove the stale `tools.web_search=false` override
- change the default reasoning effort from `minimal` to `low`

This restored compatibility with the current Codex CLI provider flow for me.