### PR TITLE
fix: restore Codex CLI compatibility with current config schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Example `~/.qq/config.json` fragment that pins Codex as the default profile:
     "codex": {
       "model_provider": "codex",
       "model": "gpt-5",
-      "reasoning_effort": "minimal"
+      "reasoning_effort": "low"
     }
   }
 }

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -636,13 +636,11 @@ mod cli_backend {
             cmd.arg("--skip-git-repo-check");
         }
         cmd.arg("--json");
-        let reasoning = req.reasoning_effort.unwrap_or("minimal");
+        let reasoning = req.reasoning_effort.unwrap_or("low");
         cmd.arg("-c");
         cmd.arg(format!("model_reasoning_effort={}", reasoning));
         cmd.arg("-c");
         cmd.arg("sandbox_mode=read-only");
-        cmd.arg("-c");
-        cmd.arg("tools.web_search=false");
         cmd.arg("-");
 
         let prompt = format!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -291,7 +291,7 @@ impl Default for Config {
             Profile {
                 model_provider: "codex".to_string(),
                 model: "gpt-5".to_string(),
-                reasoning_effort: Some("minimal".to_string()),
+                reasoning_effort: Some("low".to_string()),
                 temperature: None,
                 timeout: None,
             },

--- a/tests/cli_backend_tests.rs
+++ b/tests/cli_backend_tests.rs
@@ -127,7 +127,7 @@ printf '%s\n' '{{"type":"item.completed","item":{{"type":"agent_message","text":
         system_prompt: "SYSTEM",
         user_prompt: "USER",
         model: "gpt-5",
-        reasoning_effort: Some("minimal"),
+        reasoning_effort: Some("low"),
         debug: false,
         timeout: Duration::from_secs(5),
     })
@@ -142,11 +142,9 @@ printf '%s\n' '{{"type":"item.completed","item":{{"type":"agent_message","text":
         "--skip-git-repo-check",
         "--json",
         "-c",
-        "model_reasoning_effort=minimal",
+        "model_reasoning_effort=low",
         "-c",
         "sandbox_mode=read-only",
-        "-c",
-        "tools.web_search=false",
         "-",
     ]
     .into_iter()


### PR DESCRIPTION
## Summary
- Remove the stale `tools.web_search=false` Codex config override (current Codex CLI expects a struct, not a boolean).
- Default Codex reasoning effort to `low` instead of `minimal`, matching current Codex CLI constraints.
- Update the bundled `codex` profile default and CLI backend test expectations.

Supersedes #47 — thanks @BorisEagle for reporting and the initial patch.

## Test plan
- [x] `cargo test`
- [ ] Smoke test with real Codex CLI: `qq --profile codex "list files here"`


Made with [Cursor](https://cursor.com)