### PR TITLE
fix: add OpenRouter guidance when API returns 402

### DIFF
--- a/src/ai.rs
+++ b/src/ai.rs
@@ -18,6 +18,18 @@ pub const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 180;
 const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 10;
 const DEFAULT_TEMPERATURE: f32 = 0.15;
 
+fn format_api_error(status: reqwest::StatusCode, body: &str, base_url: &str) -> anyhow::Error {
+    let mut message = format!("API error ({}): {}", status, body);
+    if status.as_u16() == 402 && base_url.contains("openrouter.ai") {
+        message.push_str(
+            "\n\nOpenRouter hint: many models require a positive credit balance even when using free variants. \
+Try a model slug ending in :free (for example openrouter/free), or add credits at \
+https://openrouter.ai/settings/credits . See https://openrouter.ai/docs/faq for free-tier limits.",
+        );
+    }
+    anyhow!(message)
+}
+
 /// Minimal OpenAI-compatible chat streaming delta payload
 #[derive(Debug, Deserialize)]
 struct ChatStreamChunkChoiceDelta {
@@ -271,7 +283,7 @@ impl ChatClient {
         let status = resp.status();
         let text = resp.text().await?;
         if !status.is_success() {
-            return Err(anyhow!("API error ({}): {}", status, text));
+            return Err(format_api_error(status, &text, &self.base_url));
         }
         let parsed: ChatResponse = serde_json::from_str(&text)
             .with_context(|| format!("Failed to parse chat response JSON: {}", text))?;
@@ -308,7 +320,7 @@ impl ChatClient {
         let status = resp.status();
         let text = resp.text().await?;
         if !status.is_success() {
-            return Err(anyhow!("API error ({}): {}", status, text));
+            return Err(format_api_error(status, &text, &self.base_url));
         }
         let parsed: ChatResponse = serde_json::from_str(&text)
             .with_context(|| format!("Failed to parse chat response JSON: {}", text))?;
@@ -347,7 +359,7 @@ impl ChatClient {
         let status = resp.status();
         let text = resp.text().await?;
         if !status.is_success() {
-            return Err(anyhow!("API error ({}): {}", status, text));
+            return Err(format_api_error(status, &text, &self.base_url));
         }
 
         // Try to parse as tool-aware response first
@@ -413,7 +425,7 @@ impl ChatClient {
         if !resp.status().is_success() {
             let status = resp.status();
             let text = resp.text().await.unwrap_or_default();
-            return Err(anyhow!("API error ({}): {}", status, text));
+            return Err(format_api_error(status, &text, &self.base_url));
         }
 
         // The OpenAI-compatible API returns text/event-stream with lines prefixed by "data: ".
@@ -493,7 +505,7 @@ impl ChatClient {
         if !resp.status().is_success() {
             let status = resp.status();
             let text = resp.text().await.unwrap_or_default();
-            return Err(anyhow!("API error ({}): {}", status, text));
+            return Err(format_api_error(status, &text, &self.base_url));
         }
 
         // Reuse the same SSE parsing as non-message streaming
@@ -1209,6 +1221,31 @@ mod tests {
     use rcgen::{CertifiedKey, generate_simple_self_signed};
     use std::fs;
     use tempfile::tempdir;
+
+    #[test]
+    fn format_api_error_adds_openrouter_hint_for_402() {
+        let err = super::format_api_error(
+            reqwest::StatusCode::PAYMENT_REQUIRED,
+            r#"{"error":{"message":"Insufficient credits"}}"#,
+            "https://openrouter.ai/api/v1",
+        );
+        let msg = err.to_string();
+        assert!(msg.contains(":free"));
+        assert!(msg.contains("openrouter.ai/settings/credits"));
+    }
+
+    #[test]
+    fn format_api_error_omits_openrouter_hint_for_other_providers() {
+        let err = super::format_api_error(
+            reqwest::StatusCode::PAYMENT_REQUIRED,
+            r#"{"error":{"message":"Insufficient credits"}}"#,
+            "https://api.openai.com/v1",
+        );
+        assert_eq!(
+            err.to_string(),
+            r#"API error (402 Payment Required): {"error":{"message":"Insufficient credits"}}"#
+        );
+    }
 
     #[test]
     fn load_root_certificates_supports_multiple_pem_entries() {


### PR DESCRIPTION
## Summary
- When OpenRouter returns HTTP 402, append a short hint about `:free` model slugs and credit balance requirements.
- Helps users hitting #39 without changing OpenRouter billing behavior.

This is **not** a qqqa bug: OpenRouter returns 402 when the account has never purchased credits or the balance is negative, even for some free-tier usage. Reporters were using paid slugs like `openai/gpt-oss-20b` rather than `:free` variants.

## Test plan
- [x] `cargo test` (including new unit tests for hint formatting)
- [ ] Trigger a 402 against OpenRouter and confirm the appended hint appears

Fixes #39 (documentation/UX side; users may still need to add credits or pick `:free` models).


Made with [Cursor](https://cursor.com)